### PR TITLE
Fallbacks for topology-aware load balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Note that, you would still need to specify `load_balance=true` to enable the top
 ```
 "postgres://username:password@localhost:5433/database_name?load_balance=true&topology_keys=cloud1.region1.zone1,cloud1.region1.zone2"
 ```
-## Specifying fallback zones
+### Specifying fallback zones
 
 For topology-aware load balancing, you can now specify fallback placements too. This is not applicable for cluster-aware load balancing.
 Each placement value can be suffixed with a colon (`:`) followed by a preference value between 1 and 10.
@@ -42,7 +42,6 @@ A preference value of `:1` means it is a primary placement. A preference value o
 
 ```
 String yburl = "postgres://username:password@localhost:5433/database_name?load_balance=true&topology_keys=cloud1.region1.zone1:1,cloud1.region1.zone2:2";
-
 ```
 
 You can also use `*` for specifying all the zones in a given region as shown below. This is not allowed for cloud or region values.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,36 @@ Note that, you would still need to specify `load_balance=true` to enable the top
 ```
 "postgres://username:password@localhost:5433/database_name?load_balance=true&topology_keys=cloud1.region1.zone1,cloud1.region1.zone2"
 ```
+## Specifying fallback zones
+
+For topology-aware load balancing, you can now specify fallback placements too. This is not applicable for cluster-aware load balancing.
+Each placement value can be suffixed with a colon (`:`) followed by a preference value between 1 and 10.
+A preference value of `:1` means it is a primary placement. A preference value of `:2` means it is the first fallback placement and so on.If no preference value is provided, it is considered to be a primary placement (equivalent to one with preference value `:1`). Example given below.
+
+```
+String yburl = "postgres://username:password@localhost:5433/database_name?load_balance=true&topology_keys=cloud1.region1.zone1:1,cloud1.region1.zone2:2";
+
+```
+
+You can also use `*` for specifying all the zones in a given region as shown below. This is not allowed for cloud or region values.
+
+```
+String yburl = "postgres://username:password@localhost:5433/database_name?load_balance=true&topology_keys=cloud1.region1.*:1,cloud1.region2.*:2";
+```
+
+The driver attempts connection to servers in the first fallback placement(s) if it does not find any servers available in the primary placement(s). If no servers are available in the first fallback placement(s),
+then it attempts to connect to servers in the second fallback placement(s), if specified. This continues until the driver finds a server to connect to, else an error is returned to the application.
+And this repeats for each connection request.
+
+## Specifying Refresh Interval
+
+Users can specify Refresh Time Interval, in seconds. It is the time interval between two attempts to refresh the information about cluster nodes. Default is 300. Valid values are integers between 0 and 600. Value 0 means refresh for each connection request. Any value outside this range is ignored and the default is used.
+
+To specify Refresh Interval, use the parameter `yb_servers_refresh_interval` in the connection url or the connection string.
+
+```
+String yburl = "postgres://username:password@localhost:5433/database_name?yb_servers_refresh_interval=X&load_balance=true&topology_keys=cloud1.region1.*:1,cloud1.region2.*:2";
+```
 
 Same parameters can be specified in the connection url while using the `pgxpool.Connect()` API.
 

--- a/conn.go
+++ b/conn.go
@@ -213,15 +213,15 @@ func ParseConfig(connString string) (*ConnConfig, error) {
 					topologyKeys[0] = append(topologyKeys[0], zones[0])
 				} else {
 					num, err := strconv.Atoi(zones[1])
-					if err != nil {
-						return nil, fmt.Errorf("Invalid preference value for ", zones[0], ": ", num)
-					}
-					if num < 1 || num > MAX_PREFERENCE_VALUE {
-						return nil, fmt.Errorf("Invalid preference value for ", zones[0], ": ", num)
+					if err != nil || num < 1 || num > MAX_PREFERENCE_VALUE {
+						str := "Invalid preference value for " + zones[0] + ": " + zones[1]
+						return nil, fmt.Errorf(str)
 					}
 					topologyKeys[num-1] = append(topologyKeys[num-1], zones[0])
 				}
 			}
+		} else {
+			return nil, err
 		}
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -41,7 +41,7 @@ type ConnConfig struct {
 	createdByParseConfig bool // Used to enforce created by ParseConfig rule.
 
 	loadBalance     bool
-	topologyKeys    []string
+	topologyKeys    map[int][]string
 	refreshInterval int64
 }
 
@@ -202,13 +202,26 @@ func ParseConfig(connString string) (*ConnConfig, error) {
 		}
 	}
 
-	var topologyKeys []string = nil
+	var topologyKeys map[int][]string = nil
 	if s, ok := config.RuntimeParams["topology_keys"]; ok {
 		delete(config.RuntimeParams, "topology_keys")
 		if tkeys, err := validateTopologyKeys(s); err == nil {
-			topologyKeys = tkeys
-		} else {
-			return nil, fmt.Errorf("invalid topology_keys: %v", err)
+			topologyKeys = make(map[int][]string)
+			for _, tk := range tkeys {
+				zones := strings.Split(tk, ":")
+				if len(zones) == 1 {
+					topologyKeys[0] = append(topologyKeys[0], zones[0])
+				} else {
+					num, err := strconv.Atoi(zones[1])
+					if err != nil {
+						return nil, fmt.Errorf("invalid PREFERENCE_VALUE")
+					}
+					if num < 1 || num > MAX_PREFERENCE_VALUE {
+						return nil, fmt.Errorf("Invalid preference value for property ", zones[0], " : ", num)
+					}
+					topologyKeys[num-1] = append(topologyKeys[num-1], zones[0])
+				}
+			}
 		}
 	}
 
@@ -216,7 +229,11 @@ func ParseConfig(connString string) (*ConnConfig, error) {
 	if s, ok := config.RuntimeParams["refresh_interval"]; ok {
 		delete(config.RuntimeParams, "refresh_interval")
 		if refresh, err := strconv.Atoi(s); err == nil {
-			refreshInterval = int64(refresh)
+			if refresh >= 0 && refresh <= MAX_INTERVAL_SECONDS {
+				refreshInterval = int64(refresh)
+			} else {
+				return nil, fmt.Errorf("refresh_interval has to be >=0 and <=600")
+			}
 		} else {
 			return nil, fmt.Errorf("invalid refresh_interval: %v", err)
 		}

--- a/conn.go
+++ b/conn.go
@@ -214,10 +214,10 @@ func ParseConfig(connString string) (*ConnConfig, error) {
 				} else {
 					num, err := strconv.Atoi(zones[1])
 					if err != nil {
-						return nil, fmt.Errorf("invalid PREFERENCE_VALUE")
+						return nil, fmt.Errorf("Invalid preference value for ", zones[0], ": ", num)
 					}
 					if num < 1 || num > MAX_PREFERENCE_VALUE {
-						return nil, fmt.Errorf("Invalid preference value for property ", zones[0], " : ", num)
+						return nil, fmt.Errorf("Invalid preference value for ", zones[0], ": ", num)
 					}
 					topologyKeys[num-1] = append(topologyKeys[num-1], zones[0])
 				}
@@ -226,8 +226,8 @@ func ParseConfig(connString string) (*ConnConfig, error) {
 	}
 
 	refreshInterval := int64(REFRESH_INTERVAL_SECONDS)
-	if s, ok := config.RuntimeParams["refresh_interval"]; ok {
-		delete(config.RuntimeParams, "refresh_interval")
+	if s, ok := config.RuntimeParams["yb_servers_refresh_interval"]; ok {
+		delete(config.RuntimeParams, "yb_servers_refresh_interval")
 		if refresh, err := strconv.Atoi(s); err == nil {
 			if refresh >= 0 && refresh <= MAX_INTERVAL_SECONDS {
 				refreshInterval = int64(refresh)

--- a/conn.go
+++ b/conn.go
@@ -231,8 +231,6 @@ func ParseConfig(connString string) (*ConnConfig, error) {
 		if refresh, err := strconv.Atoi(s); err == nil {
 			if refresh >= 0 && refresh <= MAX_INTERVAL_SECONDS {
 				refreshInterval = int64(refresh)
-			} else {
-				return nil, fmt.Errorf("refresh_interval has to be >=0 and <=600")
 			}
 		} else {
 			return nil, fmt.Errorf("invalid refresh_interval: %v", err)

--- a/load_balance.go
+++ b/load_balance.go
@@ -360,9 +360,9 @@ func getHostWithLeastConns(li *ClusterLoadInfo) *lbHost {
 		for i := 0; i < len(li.config.topologyKeys); i++ {
 			var servers []string
 			for _, tk := range li.config.topologyKeys[i] {
-				ToCheckStar := strings.Split(tk, ".")
-				if ToCheckStar[2] == "*" {
-					tk = ToCheckStar[0] + "." + ToCheckStar[1]
+				toCheckStar := strings.Split(tk, ".")
+				if toCheckStar[2] == "*" {
+					tk = toCheckStar[0] + "." + toCheckStar[1]
 				}
 				servers = append(servers, li.zoneList[tk]...)
 			}

--- a/load_balance.go
+++ b/load_balance.go
@@ -15,6 +15,8 @@ import (
 const NO_SERVERS_MSG = "could not find a server to connect to"
 const MAX_RETRIES = 20
 const REFRESH_INTERVAL_SECONDS = 300
+const MAX_INTERVAL_SECONDS = 600
+const MAX_PREFERENCE_VALUE = 10
 
 // -- Values for ClusterLoadInfo.flags --
 // Use private address (host) of tservers to create a connection
@@ -322,12 +324,19 @@ func refreshLoadInfo(li *ClusterLoadInfo) error {
 		} else {
 			li.hostPairs[host] = publicIP
 			tk := cloud + "." + region + "." + zone
+			tk_star := cloud + "." + region // Used for topology_keys of type: cloud.region.*
 			hosts, ok := li.zoneList[tk]
 			if !ok {
 				hosts = make([]string, 0)
 			}
+			hosts_star, ok_star := li.zoneList[tk_star]
+			if !ok_star {
+				hosts_star = make([]string, 0)
+			}
 			hosts = append(hosts, host)
+			hosts_star = append(hosts_star, host)
 			li.zoneList[tk] = hosts
+			li.zoneList[tk_star] = hosts_star
 			cnt := li.hostLoad[host]
 			newHostLoad[host] = cnt
 			li.hostPort[host] = uint16(port)
@@ -348,14 +357,26 @@ func getHostWithLeastConns(li *ClusterLoadInfo) *lbHost {
 	leastCnt := int(math.MaxInt64)
 	leastLoaded := ""
 	if li.config.topologyKeys != nil {
-		for _, tk := range li.config.topologyKeys {
-			for _, h := range li.zoneList[tk] {
+		for i := 0; i < len(li.config.topologyKeys); i++ {
+			var servers []string
+			for _, tk := range li.config.topologyKeys[i] {
+				ToCheckStar := strings.Split(tk, ".")
+				if ToCheckStar[2] == "*" {
+					tk = ToCheckStar[0] + "." + ToCheckStar[1]
+				}
+				servers = append(servers, li.zoneList[tk]...)
+			}
+			for _, h := range servers {
 				if !isHostAway(li, h) && li.hostLoad[h] < leastCnt {
 					leastLoaded, leastCnt = h, li.hostLoad[h]
 				}
 			}
+			if leastCnt != int(math.MaxInt64) && leastLoaded != "" {
+				break
+			}
 		}
-	} else {
+	}
+	if leastCnt == int(math.MaxInt64) && leastLoaded == "" {
 		for h := range li.hostLoad {
 			if !isHostAway(li, h) && li.hostLoad[h] < leastCnt {
 				leastLoaded, leastCnt = h, li.hostLoad[h]
@@ -454,9 +475,12 @@ func GetAZInfo() map[string]map[string][]string {
 	for n, cli := range clustersLoadInfo {
 		az[n] = make(map[string][]string)
 		for z, hosts := range cli.zoneList {
-			newzl := make([]string, len(hosts))
-			copy(newzl, hosts)
-			az[n][z] = newzl
+			q := strings.Split(z, ".")
+			if len(q) == 3 {
+				newzl := make([]string, len(hosts))
+				copy(newzl, hosts)
+				az[n][z] = newzl
+			}
 		}
 	}
 	return az

--- a/load_balance.go
+++ b/load_balance.go
@@ -448,8 +448,9 @@ func refreshAndGetLeastLoadedHost(li *ClusterLoadInfo, awayHosts map[string]int6
 func validateTopologyKeys(s string) ([]string, error) {
 	tkeys := strings.Split(s, ",")
 	for _, tk := range tkeys {
-		zones := strings.Split(tk, ".")
-		if len(zones) != 3 {
+		zones1 := strings.Split(tk, ".")
+		zones2 := strings.Split(tk, ":")
+		if len(zones1) != 3 || len(zones2) > 2 {
 			return nil, errors.New("toplogy_keys '" + s +
 				"' not in correct format, should be specified as '<cloud>.<region>.<zone>,...'")
 		}


### PR DESCRIPTION
Changes:

Added support for fallback options for the topology-aware load balancing.


  ```
postgres://yugabyte:yugabyte@127.0.0.1:5433/yugabyte?yb_servers_refresh_interval=X&load_balance=true&topology_keys=cloud1.region1.zone1:1,cloud1.region1.zone3:2
```


- The preference value (appended after :) is optional. So it is compatible with previous syntax of specifying cloud placements. Max Preference value can be 10.

- Preference value :1 means primary placement zone(s), value :2 means first fallback, value :3 means second fallback and so on.

- Added a condition on property refresh_interval that it cannot be greater than 600 sec, if a value >600 is given, the default value which is 300 sec is taken as refresh interval.