### PR TITLE
Fixed load_balancing to work with latest Yugabyte-DB(2.17)

### DIFF
--- a/load_balance.go
+++ b/load_balance.go
@@ -64,7 +64,7 @@ type lbHost struct {
 
 var clustersLoadInfo map[string]*ClusterLoadInfo
 
-const LB_QUERY = "SELECT * FROM yb_servers()"
+const LB_QUERY = "SELECT host,port,num_connections,node_type,cloud,region,zone,public_ip FROM yb_servers()"
 
 // Only the Go routine spawned in init() reads this channel. Based on the flag, it
 // - returns the least loaded tserver's host/port (GET_LB_CONN)


### PR DESCRIPTION
A new column `uuid` is added to `yb_servers()` in the latest version of YugabyteDB, due to which LoadBalancing was giving an error, This change will fix that error.