### PR TITLE
[DB-6380] fallback issues fixed

### DIFF
--- a/load_balance.go
+++ b/load_balance.go
@@ -189,6 +189,7 @@ func produceHostName(in chan *ClusterLoadInfo, out chan *lbHost) {
 			// continue
 		} else {
 			old.config.topologyKeys = new.config.topologyKeys // Use the provided topology-keys.
+			old.config.connString = new.config.connString
 			out <- refreshAndGetLeastLoadedHost(old, new.unavailableHosts)
 			// continue
 		}
@@ -348,6 +349,7 @@ func refreshLoadInfo(li *ClusterLoadInfo) error {
 	for uh, t := range li.unavailableHosts {
 		if time.Now().Unix()-t > 30 {
 			// clear the unavailable-hosts list
+			li.hostLoad[uh] = 0
 			delete(li.unavailableHosts, uh)
 		}
 	}
@@ -505,4 +507,14 @@ func GetAZInfo() map[string]map[string][]string {
 		}
 	}
 	return az
+}
+
+// For test purpose
+func EmptyHostLoad() map[string]map[string]int {
+	for cluster := range clustersLoadInfo {
+		for host := range clustersLoadInfo[cluster].hostLoad {
+			delete(clustersLoadInfo[cluster].hostLoad, host)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
**Description**

2 issues were identified in fallback feature : 

- When a node goes down and comes back up, its number of connections was not reseting to zero.
- When a control connection is recreated, the topology_keys was getting reset to default for the next connection.

Both these issues are fixed in this PR.

`EmptyHostLoad()` method is used in some tests in [driver-examples](https://github.com/yugabyte/driver-examples) repository.