### PR TITLE
Added support for "failed-host-reconnect-delay-secs" and "fallback-to…

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -115,8 +115,7 @@ func Connect(ctx context.Context, connString string) (*Conn, error) {
 	}
 	if connConfig.loadBalance {
 		conn, err := connectLoadBalanced(ctx, connConfig)
-		var e error = ErrFallbackToOriginalBehviour
-		if err != e {
+		if err != ErrFallbackToOriginalBehaviour {
 			return conn, err
 		} else {
 			return connect(ctx, connConfig)

--- a/load_balance.go
+++ b/load_balance.go
@@ -21,7 +21,7 @@ const MAX_FAILED_HOST_RECONNECT_DELAY_SECS = 60
 const MAX_INTERVAL_SECONDS = 600
 const MAX_PREFERENCE_VALUE = 10
 
-var ErrFallbackToOriginalBehviour = errors.New("no preferred server available, fallback-to-topology-keys-only is set to true so falling back to original behaviour")
+var ErrFallbackToOriginalBehaviour = errors.New("no preferred server available, fallback-to-topology-keys-only is set to true so falling back to original behaviour")
 
 // -- Values for ClusterLoadInfo.flags --
 // Use private address (host) of tservers to create a connection
@@ -413,7 +413,7 @@ func getHostWithLeastConns(li *ClusterLoadInfo) *lbHost {
 			}
 		} else {
 			lbh := &lbHost{
-				err: ErrFallbackToOriginalBehviour,
+				err: ErrFallbackToOriginalBehaviour,
 			}
 			return lbh
 		}

--- a/load_balance.go
+++ b/load_balance.go
@@ -16,8 +16,12 @@ import (
 const NO_SERVERS_MSG = "could not find a server to connect to"
 const MAX_RETRIES = 20
 const REFRESH_INTERVAL_SECONDS = 300
+const DEFAULT_FAILED_HOST_RECONNECT_DELAY_SECS = 5
+const MAX_FAILED_HOST_RECONNECT_DELAY_SECS = 60
 const MAX_INTERVAL_SECONDS = 600
 const MAX_PREFERENCE_VALUE = 10
+
+var ErrFallbackToOriginalBehviour = errors.New("no preferred server available, fallback-to-topology-keys-only is set to true so falling back to original behaviour")
 
 // -- Values for ClusterLoadInfo.flags --
 // Use private address (host) of tservers to create a connection
@@ -190,6 +194,8 @@ func produceHostName(in chan *ClusterLoadInfo, out chan *lbHost) {
 			// continue
 		} else {
 			old.config.topologyKeys = new.config.topologyKeys // Use the provided topology-keys.
+			old.config.fallbackToTopologyKeysOnly = new.config.fallbackToTopologyKeysOnly
+			old.config.failedHostReconnectDelaySecs = new.config.failedHostReconnectDelaySecs
 			old.config.connString = new.config.connString
 			out <- refreshAndGetLeastLoadedHost(old, new.unavailableHosts)
 			// continue
@@ -353,7 +359,7 @@ func refreshLoadInfo(li *ClusterLoadInfo) error {
 	li.hostLoad = newHostLoad
 	li.lastRefresh = time.Now()
 	for uh, t := range li.unavailableHosts {
-		if time.Now().Unix()-t > 30 {
+		if time.Now().Unix()-t > li.config.failedHostReconnectDelaySecs {
 			// clear the unavailable-hosts list
 			li.hostLoad[uh] = 0
 			delete(li.unavailableHosts, uh)
@@ -393,16 +399,23 @@ func getHostWithLeastConns(li *ClusterLoadInfo) *lbHost {
 		}
 	}
 	if leastCnt == int(math.MaxInt64) && len(leastLoadedservers) == 0 {
-		for h := range li.hostLoad {
-			if !isHostAway(li, h) {
-				if li.hostLoad[h] < leastCnt {
-					leastLoadedservers = nil
-					leastLoadedservers = append(leastLoadedservers, h)
-					leastCnt = li.hostLoad[h]
-				} else if li.hostLoad[h] == leastCnt {
-					leastLoadedservers = append(leastLoadedservers, h)
+		if li.config.topologyKeys == nil || !li.config.fallbackToTopologyKeysOnly {
+			for h := range li.hostLoad {
+				if !isHostAway(li, h) {
+					if li.hostLoad[h] < leastCnt {
+						leastLoadedservers = nil
+						leastLoadedservers = append(leastLoadedservers, h)
+						leastCnt = li.hostLoad[h]
+					} else if li.hostLoad[h] == leastCnt {
+						leastLoadedservers = append(leastLoadedservers, h)
+					}
 				}
 			}
+		} else {
+			lbh := &lbHost{
+				err: ErrFallbackToOriginalBehviour,
+			}
+			return lbh
 		}
 	}
 


### PR DESCRIPTION
…-topology-keys-only"

**Description**

Following 2 new connection parameters are added with this PR:

1. `failed-host-reconnect-delay-secs` : (default value: 5 seconds) The driver marks a server as failed with a timestamp, when it cannot connect to it. Later, whenever it refreshes the server list via yb_servers(), if it sees the failed server in the response, it marks the server as UP only if failed-host-reconnect-delay-secs time has elapsed. (The yb_servers() function does not remove a failed server immediately from its result and retains it for a while.)
2. `fallback-to-topology-keys-only` : (default value: false) Applicable only for TopologyAware Load Balancing. When set to true, the smart driver does not attempt to connect to servers outside of primary and fallback placements specified via property. The default behaviour is to fallback to any available server in the entire cluster.

Tests corresponding to these 2 new connection parameter are added to driver examples repo with this [PR](https://github.com/yugabyte/driver-examples/pull/11).

**Testing**
Ran all the pgx driver examples present in [driver-examples](https://github.com/yugabyte/driver-examples) repo. 