### PR TITLE
DSN format url bug fix

### DIFF
--- a/load_balance.go
+++ b/load_balance.go
@@ -125,9 +125,9 @@ func replaceHostString(connString string, newHost string, port uint16) string {
 			newConnString = pattern.ReplaceAllString(connString, fmt.Sprintf("://%s:%d/", newHost, port))
 		}
 	} else { // key = value (DSN style)
-		pattern := regexp.MustCompile("host=([^/]*) ")
+		pattern := regexp.MustCompile("host=([^ ]*) ")
 		newConnString = pattern.ReplaceAllString(connString, fmt.Sprintf("host=%s ", newHost))
-		pattern = regexp.MustCompile("port=([^/]*) ")
+		pattern = regexp.MustCompile("port=([^ ]*) ")
 		newConnString = pattern.ReplaceAllString(newConnString, fmt.Sprintf("port=%d ", port))
 	}
 	return newConnString


### PR DESCRIPTION
**Description**
Using DSN format url to connect to the database gives the following error:

```
No hosts found, returning with NO_SERVERS_MSG
Unable to connect to database: could not find a server to connect to
exit status 1
```

With this fix the above bug is resolved and DSN format URL is working.

**Testing**
Have added a test for DSN url in driver-examples repo. PR: https://github.com/yugabyte/driver-examples/pull/17