### PR TITLE
Propagate DialFunc to host connections

### DIFF
--- a/load_balance.go
+++ b/load_balance.go
@@ -222,6 +222,7 @@ func connectLoadBalanced(ctx context.Context, config *ConnConfig) (c *Conn, err 
 		newConfig.Port = lbHost.port
 		newConfig.controlHost = config.controlHost
 		newConfig.TLSConfig = config.TLSConfig
+		newConfig.DialFunc = config.DialFunc
 		return connectWithRetries(ctx, config.controlHost, newConfig, newLoadInfo, lbHost)
 	}
 }
@@ -252,6 +253,7 @@ func connectWithRetries(ctx context.Context, controlHost string, newConfig *Conn
 		} else {
 			newConnString := strings.Replace(newConfig.connString, newConfig.Host, lbHost.hostname, -1)
 			oldTLSConfig := newConfig.TLSConfig
+			oldDialFunc := newConfig.DialFunc
 			newConfig, err = ParseConfig(newConnString)
 			if err != nil {
 				return nil, err
@@ -259,6 +261,7 @@ func connectWithRetries(ctx context.Context, controlHost string, newConfig *Conn
 			newConfig.Port = lbHost.port
 			newConfig.controlHost = controlHost
 			newConfig.TLSConfig = oldTLSConfig
+			newConfig.DialFunc = oldDialFunc
 			conn, err = connect(ctx, newConfig)
 		}
 	}


### PR DESCRIPTION
**Description**
Propagate DialFunc to host connection configs since those are not parsed with the connection string.  This maintains KeepAlive and TCP connect timeout for individual host connections.

**Testing**
1. Create a YDB Cluster
2. Configure PGX with a DialFunc that sets either KeepAlive or TCP Connect Timeout and load_balance=true.
3. Introduce a firewall between the application running this PGX driver and a select number of YDB nodes.  Make sure that `yb_servers()` still returns the full list of YDB nodes.
4. Validate that host connections respect TCP connect timeout and KeepAlive.  Without DialFunc propagated, host connections will hang on TCP connect indefinitely (defaults to no timeout) or until Go context timeout elapses.

Tested against 4.14.7