### PR TITLE
Adding support for Read replica clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Users can use this feature in two configurations.
 
 In the cluster-aware connection load balancing, connections are distributed across all the tservers in the cluster, irrespective of their placements.
 
-To enable the cluster-aware connection load balancing, provide the parameter `load_balance` set to true as `load_balance=true` in the connection url or the connection string (DSN style).
+To enable the cluster-aware connection load balancing, provide the parameter `load_balance` set to true or any as `load_balance=any` in the connection url or the connection string (DSN style).
 
 ```
-"postgres://username:password@localhost:5433/database_name?load_balance=true"
+"postgres://username:password@localhost:5433/database_name?load_balance=any"
 ```
 
 With this parameter specified in the url, the driver will fetch and maintain the list of tservers from the given endpoint (`localhost` in above example) available in the YugabyteDB cluster and distribute the connections equally across them.
@@ -28,10 +28,10 @@ With topology-aware connnection load balancing, users can target tservers in spe
 
 The connections will be distributed equally with the tservers in these zones.
 
-Note that, you would still need to specify `load_balance=true` to enable the topology-aware connection load balancing.
+Note that, you would still need to specify `load_balance=any` to enable the topology-aware connection load balancing.
 
 ```
-"postgres://username:password@localhost:5433/database_name?load_balance=true&topology_keys=cloud1.region1.zone1,cloud1.region1.zone2"
+"postgres://username:password@localhost:5433/database_name?load_balance=any&topology_keys=cloud1.region1.zone1,cloud1.region1.zone2"
 ```
 ### Specifying fallback zones
 
@@ -40,13 +40,13 @@ Each placement value can be suffixed with a colon (`:`) followed by a preference
 A preference value of `:1` means it is a primary placement. A preference value of `:2` means it is the first fallback placement and so on.If no preference value is provided, it is considered to be a primary placement (equivalent to one with preference value `:1`). Example given below.
 
 ```
-"postgres://username:password@localhost:5433/database_name?load_balance=true&topology_keys=cloud1.region1.zone1:1,cloud1.region1.zone2:2";
+"postgres://username:password@localhost:5433/database_name?load_balance=any&topology_keys=cloud1.region1.zone1:1,cloud1.region1.zone2:2";
 ```
 
 You can also use `*` for specifying all the zones in a given region as shown below. This is not allowed for cloud or region values.
 
 ```
-"postgres://username:password@localhost:5433/database_name?load_balance=true&topology_keys=cloud1.region1.*:1,cloud1.region2.*:2";
+"postgres://username:password@localhost:5433/database_name?load_balance=any&topology_keys=cloud1.region1.*:1,cloud1.region2.*:2";
 ```
 
 The driver attempts to connect to a node in following order: the least loaded node in the 1) primary placement(s), else in the 2) first fallback if specified, else in the 3) second fallback if specified and so on.
@@ -60,12 +60,31 @@ Users can specify Refresh Time Interval, in seconds. It is the time interval bet
 To specify Refresh Interval, use the parameter `yb_servers_refresh_interval` in the connection url or the connection string.
 
 ```
-"postgres://username:password@localhost:5433/database_name?yb_servers_refresh_interval=X&load_balance=true&topology_keys=cloud1.region1.*:1,cloud1.region2.*:2";
+"postgres://username:password@localhost:5433/database_name?yb_servers_refresh_interval=X&load_balance=any&topology_keys=cloud1.region1.*:1,cloud1.region2.*:2";
 ```
 
 Same parameters can be specified in the connection url while using the `pgxpool.Connect()` API.
 
-For a working example which demonstrates both the configurations of connection load balancing using `pgx.Connect()` and `pgxpool.Connect()`, see the [driver-examples](https://github.com/yugabyte/driver-examples/tree/main/go/pgx) repository.
+## Other Connection Parameters:
+
+### fallback_to_topology_keys_only
+Applicable only for TopologyAware Load Balancing. When set to true, the smart driver does not attempt to connect to servers outside of primary and fallback placements specified via property. The default behaviour is to fallback to any available server in the entire cluster.(default value: false)
+
+### failed_host_reconnect_delay_secs
+The driver marks a server as failed with a timestamp, when it cannot connect to it. Later, whenever it refreshes the server list via yb_servers(), if it sees the failed server in the response, it marks the server as UP only if failed-host-reconnect-delay-secs time has elapsed. (The yb_servers() function does not remove a failed server immediately from its result and retains it for a while.)(default value: 5 seconds)
+
+## Read Replica Cluster
+
+PGX smart driver also supports Primary clusters which have associated Read Replica cluster.
+
+The connection property `load-balance` allows five values using which users can distribute connections among different combination of nodes as per their requirements:
+`only-rr` - Create connections only on Read Replica nodes
+`only-primary` - Create connections only on primary cluster nodes
+`prefer-rr` - Create connections on Read Replica nodes. If none available, on any node in the cluster including primary cluster nodes
+`prefer-primary` - Create connections on primary cluster nodes. If none available, on any node in the cluster including Read Replica nodes
+`any` or `true` - Equivalent to value true. Create connections on any node in the primary or Read Replica cluster
+
+default value is false
 
 Details about the upstream pgx driver - which hold true for this driver as well - are given below.
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ The driver marks a server as failed with a timestamp, when it cannot connect to 
 PGX smart driver also supports Primary clusters which have associated Read Replica cluster.
 
 The connection property `load-balance` allows five values using which users can distribute connections among different combination of nodes as per their requirements:
-`only-rr` - Create connections only on Read Replica nodes
-`only-primary` - Create connections only on primary cluster nodes
-`prefer-rr` - Create connections on Read Replica nodes. If none available, on any node in the cluster including primary cluster nodes
-`prefer-primary` - Create connections on primary cluster nodes. If none available, on any node in the cluster including Read Replica nodes
-`any` or `true` - Equivalent to value true. Create connections on any node in the primary or Read Replica cluster
+
+- `only-rr` - Create connections only on Read Replica nodes
+- `only-primary` - Create connections only on primary cluster nodes
+- `prefer-rr` - Create connections on Read Replica nodes. If none available, on any node in the cluster including primary cluster nodes
+- `prefer-primary` - Create connections on primary cluster nodes. If none available, on any node in the cluster including Read Replica nodes
+- `any` or `true` - Equivalent to value true. Create connections on any node in the primary or Read Replica cluster
 
 default value is false
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Users can use this feature in two configurations.
 
 In the cluster-aware connection load balancing, connections are distributed across all the tservers in the cluster, irrespective of their placements.
 
-To enable the cluster-aware connection load balancing, provide the parameter `load_balance` set to true or any as `load_balance=any` in the connection url or the connection string (DSN style).
+To enable the cluster-aware connection load balancing, provide the parameter `load_balance` with value as either `true` or `any` in the connection url or the connection string (DSN style). [This section](url-todo) explains the different values for `load_balance` parameter.
 
 ```
 "postgres://username:password@localhost:5433/database_name?load_balance=any"
@@ -75,7 +75,7 @@ The driver marks a server as failed with a timestamp, when it cannot connect to 
 
 ## Read Replica Cluster
 
-PGX smart driver also supports Primary clusters which have associated Read Replica cluster.
+PGX smart driver also enables load balancing across nodes in primary clusters which have associated Read Replica cluster.
 
 The connection property `load-balance` allows five values using which users can distribute connections among different combination of nodes as per their requirements:
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ See the presentation at Golang Estonia, [PGX Top to Bottom](https://www.youtube.
 
 ## Supported Go and PostgreSQL Versions
 
-pgx supports the same versions of Go and PostgreSQL that are supported by their respective teams. For [Go](https://golang.org/doc/devel/release.html#policy) that is the two most recent major releases and for [PostgreSQL](https://www.postgresql.org/support/versioning/) the major releases in the last 5 years. This means pgx supports Go 1.20 and higher and PostgreSQL 12 and higher. pgx also is tested against the latest version of [CockroachDB](https://www.cockroachlabs.com/product/).
+pgx supports the same versions of Go and PostgreSQL that are supported by their respective teams. For [Go](https://golang.org/doc/devel/release.html#policy) that is the two most recent major releases and for [PostgreSQL](https://www.postgresql.org/support/versioning/) the major releases in the last 5 years. This means pgx supports Go 1.20 and higher and PostgreSQL 12 and higher.
 
 ## Version Policy
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Users can use this feature in two configurations.
 
 In the cluster-aware connection load balancing, connections are distributed across all the tservers in the cluster, irrespective of their placements.
 
-To enable the cluster-aware connection load balancing, provide the parameter `load_balance` with value as either `true` or `any` in the connection url or the connection string (DSN style). [This section](url-todo) explains the different values for `load_balance` parameter.
+To enable the cluster-aware connection load balancing, provide the parameter `load_balance` with value as either `true` or `any` in the connection url or the connection string (DSN style). [This section](#read-replica-cluster) explains the different values for `load_balance` parameter.
 
 ```
 "postgres://username:password@localhost:5433/database_name?load_balance=true"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In the cluster-aware connection load balancing, connections are distributed acro
 To enable the cluster-aware connection load balancing, provide the parameter `load_balance` with value as either `true` or `any` in the connection url or the connection string (DSN style). [This section](url-todo) explains the different values for `load_balance` parameter.
 
 ```
-"postgres://username:password@localhost:5433/database_name?load_balance=any"
+"postgres://username:password@localhost:5433/database_name?load_balance=true"
 ```
 
 With this parameter specified in the url, the driver will fetch and maintain the list of tservers from the given endpoint (`localhost` in above example) available in the YugabyteDB cluster and distribute the connections equally across them.
@@ -28,10 +28,10 @@ With topology-aware connnection load balancing, users can target tservers in spe
 
 The connections will be distributed equally with the tservers in these zones.
 
-Note that, you would still need to specify `load_balance=any` to enable the topology-aware connection load balancing.
+Note that, you would still need to specify `load_balance` to one of the 5 allowed values to enable the topology-aware connection load balancing.
 
 ```
-"postgres://username:password@localhost:5433/database_name?load_balance=any&topology_keys=cloud1.region1.zone1,cloud1.region1.zone2"
+"postgres://username:password@localhost:5433/database_name?load_balance=true&topology_keys=cloud1.region1.zone1,cloud1.region1.zone2"
 ```
 ### Specifying fallback zones
 
@@ -60,7 +60,7 @@ Users can specify Refresh Time Interval, in seconds. It is the time interval bet
 To specify Refresh Interval, use the parameter `yb_servers_refresh_interval` in the connection url or the connection string.
 
 ```
-"postgres://username:password@localhost:5433/database_name?yb_servers_refresh_interval=X&load_balance=any&topology_keys=cloud1.region1.*:1,cloud1.region2.*:2";
+"postgres://username:password@localhost:5433/database_name?yb_servers_refresh_interval=X&load_balance=true&topology_keys=cloud1.region1.*:1,cloud1.region2.*:2";
 ```
 
 Same parameters can be specified in the connection url while using the `pgxpool.Connect()` API.

--- a/conn.go
+++ b/conn.go
@@ -208,7 +208,7 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 	var loadBalance string = "false"
 	if s, ok := config.RuntimeParams["load_balance"]; ok {
 		delete(config.RuntimeParams, "load_balance")
-		if validateLoadBalnce(s) {
+		if validateLoadBalance(s) {
 			loadBalance = s
 		} else {
 			return nil, fmt.Errorf("invalid load_balance value: Valid values are only-rr, only-primary, prefer-rr, prefer-primary, any or true")

--- a/load_balance.go
+++ b/load_balance.go
@@ -2,12 +2,13 @@ package pgx
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"log"
 	"maps"
 	"math"
-	"math/rand"
+	"math/big"
 	"net"
 	"regexp"
 	"strings"
@@ -554,8 +555,11 @@ func getHostWithLeastConns(li *ClusterLoadInfo) *lbHost {
 	}
 
 	if len(leastLoadedservers) != 0 {
-		rand.Seed(time.Now().UnixNano())
-		leastLoaded = leastLoadedservers[rand.Intn(len(leastLoadedservers))]
+		randomIndex, err := rand.Int(rand.Reader, big.NewInt(int64(len(leastLoadedservers))))
+		if err != nil {
+			log.Fatalf("Could not select a leastloadedserver randomly")
+		}
+		leastLoaded = leastLoadedservers[randomIndex.Int64()]
 	}
 
 	if leastLoaded == "" {


### PR DESCRIPTION
IDEA: [IDEA-752](https://yugabyte.atlassian.net/browse/IDEA-752)

Implementation details: [Doc](https://docs.google.com/document/d/1SqT7IMM5DuHav7fl_xGt8pfCMp5dnJ6-MrLVftbIows/edit#heading=h.4p1zl0z1krwh)

The connection property `load-balance` currently allows only two values, viz. `false` (the default) and `true`.

It will now also allow below five new values to be specified:
`only-rr` - Create connections only on Read Replica nodes
`only-primary`- Create connections only on primary cluster nodes
`prefer-rr` - Create connections on Read Replica nodes. If none available, on any node in the cluster including primary cluster nodes
`prefer-primary` - Create connections on primary cluster nodes. If none available, on any node in the cluster including Read Replica nodes
`any` - Equivalent to value true. Create connections on any node in the primary or Read Replica cluster

default value is still `false`

Other Minor changes:

- Corrected the behaviour of `fallback-to-topology-keys-only` connection property. When `fallback-to-topology-keys-only` is set to `true` and all the nodes of the specified topology_keys are down, the driver currently fallbacks to upstream driver behaviour but the driver is expected to throw an error in this case which is corrected in this PR.
- Removed `connection count for .. going negative!` logs: [DB-9240](https://yugabyte.atlassian.net/browse/DB-9240)
- Fixed security vulnerability: [DB-6258](https://yugabyte.atlassian.net/browse/DB-6258) by replacing math/rand with crypto/rand.

**Testing:**
Test cases identified and listed in this [doc](https://docs.google.com/document/d/1gBxuv1mgTszGAoleYV1_fQdZxIGC-dssCN3XfKuSA2A/edit).
Test for all test cases listed in the doc added to driver-example repo: [PR LINK](https://github.com/yugabyte/driver-examples/pull/25).
Ran the existing and new tests in driver examples repo for pgx.