### PR TITLE
Config fix

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -141,7 +141,11 @@ func ConnectWithOptions(ctx context.Context, connString string, options ParseCon
 	if err != nil {
 		return nil, err
 	}
-	return connect(ctx, connConfig)
+	if connConfig.loadBalance != "false" {
+		return connectLoadBalanced(ctx, connConfig)
+	} else {
+		return connect(ctx, connConfig)
+	}
 }
 
 // ConnectConfig establishes a connection with a PostgreSQL server with a configuration struct.

--- a/load_balance.go
+++ b/load_balance.go
@@ -227,6 +227,8 @@ func connectLoadBalanced(ctx context.Context, config *ConnConfig) (c *Conn, err 
 		return connect(ctx, config) // fallback to original behaviour
 	}
 	if lbHost.hostname == config.Host {
+		config.Fallbacks = config.Fallbacks[:1]
+		config.connString = replaceHostString(config.connString, lbHost.hostname, lbHost.port)
 		return connectWithRetries(ctx, config.controlHost, config, newLoadInfo, lbHost)
 	} else {
 		log.Printf("Replacing %s:%d with %s:%d in conn config", config.Host, config.Port, lbHost.hostname, lbHost.port)

--- a/load_balance.go
+++ b/load_balance.go
@@ -352,13 +352,14 @@ func refreshLoadInfo(li *ClusterLoadInfo) error {
 				return err
 			}
 		}
+		li.config.controlHost = li.config.Host
 	}
 	// defer li.controlConn.Close(li.ctrlCtx)
 
 	rows, err := li.controlConn.Query(li.ctrlCtx, LB_QUERY)
 	if err != nil {
 		log.Printf("Could not query load information: %s", err.Error())
-		markHostAway(li, li.config.Host)
+		markHostAway(li, li.config.controlHost)
 		li.controlConn = nil
 		return refreshLoadInfo(li)
 	}
@@ -378,7 +379,7 @@ func refreshLoadInfo(li *ClusterLoadInfo) error {
 		err := rows.Scan(&host, &port, &numConns, &nodeType, &cloud, &region, &zone, &publicIP)
 		if err != nil {
 			log.Printf("Could not read load information: %s", err.Error())
-			markHostAway(li, li.config.Host)
+			markHostAway(li, li.config.controlHost)
 			li.controlConn = nil
 			return refreshLoadInfo(li)
 		} else {
@@ -401,7 +402,7 @@ func refreshLoadInfo(li *ClusterLoadInfo) error {
 	rsError := rows.Err()
 	if rsError != nil {
 		log.Printf("refreshLoadInfo(): Could not read load information, Rows.Err(): %s", rsError.Error())
-		markHostAway(li, li.config.Host)
+		markHostAway(li, li.config.controlHost)
 		li.controlConn = nil
 		return refreshLoadInfo(li)
 	}


### PR DESCRIPTION
Resolves [DB-12244](https://yugabyte.atlassian.net/browse/DB-12244)

**Description**

1. The connection properties set by users using connection config was not getting copied for load balanced connection due to which proper logs were not showing up for all connections on setting `Tracers` in the connection config.
2. Not able to use connection load balancing when using `ConnectWithOptions`  API of the pgx driver.

Changes included in this PR:

- Use the same connection config set in the application for all load-balanced connections and control connection.
- Call `connectLoadBalanced` from `ConnectWithOptions` if `load_balance` connection parameter is not false.